### PR TITLE
feat: Add FIA configuration files for Proxmox host

### DIFF
--- a/fia/README.md
+++ b/fia/README.md
@@ -1,0 +1,3 @@
+# FIA - Proxmox host
+
+This is the configuration for the virtual machines and linux containers that are running on the Proxmox instance.

--- a/fia/ferrari.tf
+++ b/fia/ferrari.tf
@@ -1,0 +1,42 @@
+variable "fia_node_name" {
+  type = string
+}
+
+variable "master_password" {
+  type = string
+  sensitive = true
+}
+
+variable "fia_eth" {
+  type = string
+}
+
+variable "ferrari_ip" {
+  type = string
+}
+
+resource "proxmox_lxc" "ferrari" {
+  target_node = var.fia_node_name
+  hostname = proxmox_lxc.name
+  ostemplate = "local:vztmpl/..."
+  password = var.master_password
+  unprivileged = false
+  vmid = 301
+
+  features {
+    nesting = true
+    mount = "nfs"
+  }
+
+  rootfs {
+    storage = "local-lvm"
+    size = "16G"
+  }
+
+  network {
+    # Name of the network interface inside the container
+    name = "eth0"
+    bridge = var.fia_vmbr
+    ip = var.ferrari_ip
+  }
+}

--- a/fia/providers.tf
+++ b/fia/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    proxmox = {
+      source = "Telmate/proxmox"
+      version = "2.9.14"
+    }
+  }
+}
+
+variable "fia_api_url" {
+  type = string
+}
+
+variable "fia_api_token_id" {
+  type = string
+}
+
+variable "fia_api_token_secret" {
+  type = string
+  sensitive = true
+}
+
+provider "proxmox" {
+  pm_api_url = var.fia_api_url
+  pm_api_token_id = var.fia_api_token_id
+  pm_api_token_secret = var.fia_api_token_secret
+
+  pm_tls_insecure = true
+}


### PR DESCRIPTION
This commit adds the FIA configuration files for the Proxmox host. It
includes the README.md file documenting the purpose of FIA, ferrari.tf
file defining the resources for the Ferrari container, and providers.tf
file specifying the Proxmox provider and its configuration.

The addition of these files enables seamless management and deployment
of virtual machines and Linux containers on the Proxmox instance using
Terraform and the Proxmox provider.